### PR TITLE
build: remove deprecated jcenter Gradle repository

### DIFF
--- a/gradle/repositories/build.gradle
+++ b/gradle/repositories/build.gradle
@@ -1,6 +1,5 @@
 repositories {
     mavenCentral()
-    jcenter()
     maven { url 'https://oss.sonatype.org/content/repositories/releases/' }
     maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
 }


### PR DESCRIPTION
https://blog.gradle.org/jcenter-shutdown
